### PR TITLE
Implement cart store and quantity controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "^18.2.0",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.25.64"
+        "zod": "^3.25.64",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.53.0",
@@ -8921,6 +8922,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.25.64"
+    "zod": "^3.25.64",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/src/app/[locale]/(shop)/cart/page.tsx
+++ b/src/app/[locale]/(shop)/cart/page.tsx
@@ -1,14 +1,14 @@
+'use client'
+
 import { CartItem, CartSummary, EmptyCart } from '@/features/cart/components'
-import { CartItem as CartItemType } from '@/features/cart/types'
+import { useCartStore } from '@/features/cart/store'
 
 export default function CartPage({ params: { locale } }: { params: { locale: string } }) {
-  const cartItems: CartItemType[] = [
-    { id: 1, productId: 1, name: 'プレミアムヘッドフォン', price: 29800, quantity: 1, image: '/images/placeholder.jpg' },
-    { id: 2, productId: 2, name: 'スマートウォッチ', price: 45000, quantity: 2, image: '/images/placeholder.jpg' },
-  ]
-
-  const subtotal = cartItems.reduce((sum, item) => sum + (item.price * item.quantity), 0)
-  const shipping = 500
+  const items = useCartStore(state => state.items)
+  const updateQuantity = useCartStore(state => state.updateQuantity)
+  const removeItem = useCartStore(state => state.removeItem)
+  const subtotal = useCartStore(state => state.subtotal)
+  const shipping = items.length > 0 ? 500 : 0
   const total = subtotal + shipping
 
   return (
@@ -17,17 +17,22 @@ export default function CartPage({ params: { locale } }: { params: { locale: str
         <div className="max-w-7xl mx-auto">
           <h1 className="text-4xl font-bold text-white mb-12">ショッピングカート</h1>
           
-          {cartItems.length === 0 ? (
+          {items.length === 0 ? (
             <EmptyCart locale={locale} />
           ) : (
             <div className="grid lg:grid-cols-12 gap-8">
               {/* カートアイテム一覧 */}
               <div className="lg:col-span-8 space-y-6">
                 <div className="text-zinc-300 text-sm mb-4">
-                  {cartItems.length}個の商品
+                  {items.length}個の商品
                 </div>
-                {cartItems.map((item) => (
-                  <CartItem key={item.id} item={item} />
+                {items.map((item) => (
+                  <CartItem
+                    key={item.id}
+                    item={item}
+                    onUpdateQuantity={updateQuantity}
+                    onRemove={removeItem}
+                  />
                 ))}
               </div>
               

--- a/src/app/[locale]/(shop)/products/[id]/AddToCartSection.tsx
+++ b/src/app/[locale]/(shop)/products/[id]/AddToCartSection.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { Button } from '@/components/ui'
 import { AddToCartButton } from '@/features/products/components'
 import type { Product } from '@/features/products/types'
+import { useCartStore } from '@/features/cart/store'
+import type { CartItem } from '@/features/cart/types'
 
 interface AddToCartSectionProps {
   product: Product
@@ -11,9 +13,19 @@ interface AddToCartSectionProps {
 
 export function AddToCartSection({ product }: AddToCartSectionProps) {
   const [quantity, setQuantity] = useState(1)
+  const addItem = useCartStore(state => state.addItem)
 
   const handleAddToCart = (product: Product) => {
-    console.log('Added to cart:', product, 'Quantity:', quantity)
+    const item: CartItem = {
+      id: Date.now(),
+      productId: product.id,
+      name: product.name,
+      price: product.price,
+      quantity,
+      image: product.image
+    }
+    addItem(item)
+    setQuantity(1)
   }
 
   return (

--- a/src/features/cart/components/CartItemControls.tsx
+++ b/src/features/cart/components/CartItemControls.tsx
@@ -13,6 +13,8 @@ export function CartItemControls({ item, onUpdateQuantity, onRemove }: CartItemC
   const handleDecrease = () => {
     if (item.quantity > 1) {
       onUpdateQuantity?.(item.id, item.quantity - 1);
+    } else {
+      onRemove?.(item.id);
     }
   };
 
@@ -33,7 +35,6 @@ export function CartItemControls({ item, onUpdateQuantity, onRemove }: CartItemC
           size="sm"
           onClick={handleDecrease}
           className="w-8 h-8 p-0 hover:bg-red-50 hover:border-red-200"
-          disabled={item.quantity <= 1}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />

--- a/src/features/cart/store/index.ts
+++ b/src/features/cart/store/index.ts
@@ -1,0 +1,1 @@
+export * from './useCartStore'

--- a/src/features/cart/store/useCartStore.ts
+++ b/src/features/cart/store/useCartStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { CartItem } from '../types'
+
+export interface CartStore {
+  items: CartItem[]
+  addItem: (item: CartItem) => void
+  removeItem: (id: number) => void
+  updateQuantity: (id: number, quantity: number) => void
+  clearCart: () => void
+  subtotal: number
+  total: number
+  itemCount: number
+}
+
+export const useCartStore = create<CartStore>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      addItem: (item) =>
+        set((state) => ({
+          items: [...state.items, item],
+        })),
+      removeItem: (id) =>
+        set((state) => ({
+          items: state.items.filter((item) => item.id !== id),
+        })),
+      updateQuantity: (id, quantity) =>
+        set((state) => ({
+          items: state.items
+            .map((item) =>
+              item.id === id ? { ...item, quantity } : item
+            )
+            .filter((item) => item.quantity > 0),
+        })),
+      clearCart: () => set({ items: [] }),
+      get subtotal() {
+        return get().items.reduce(
+          (sum, item) => sum + item.price * item.quantity,
+          0
+        )
+      },
+      get total() {
+        return get().subtotal
+      },
+      get itemCount() {
+        return get().items.reduce((sum, item) => sum + item.quantity, 0)
+      },
+    }),
+    { name: 'cart-storage' }
+  )
+)


### PR DESCRIPTION
## Summary
- add Zustand for cart state management
- implement cart store with localstorage persistence
- wire product page Add to Cart to store
- enable quantity change and removal in cart items

## Testing
- `npm run test` *(fails: POST /api/register > エラーハンドリング > ファイルシステムエラーを処理する)*

------
https://chatgpt.com/codex/tasks/task_e_685560c3cf248320bd780e3d8d93aef5