### PR TITLE
Add Supabase configuration guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,11 @@ NEXT_PUBLIC_SITE_NAME=Enterprise EC Demo
 # API Configuration
 NEXT_PUBLIC_API_URL=http://localhost:3000/api
 
-# Database Configuration (for future implementation)
-DATABASE_URL=sqlite:./dev.db
+# Supabase Configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+DATABASE_URL=postgresql://username:password@db.your-project.supabase.co:5432/postgres
 
 # JWT Authentication
 JWT_SECRET=your-jwt-secret-key-change-in-production-min-32-chars

--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ docs/
 NEXT_PUBLIC_SITE_URL=https://your-domain.com
 NEXT_PUBLIC_API_URL=https://api.your-domain.com
 ```
+詳しいSupabaseプロジェクトの作成手順と環境変数の設定方法は[SUPABASE_SETUP.md](./SUPABASE_SETUP.md)を参照してください。
 
 ## 🧪 テスト
 

--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -1,0 +1,33 @@
+# Supabase Setup
+
+This project can use [Supabase](https://supabase.com/) as the backend database and authentication provider. The following steps outline how to create a project, obtain API keys and configure the environment.
+
+## 1. Create a Supabase project
+1. Sign in at [supabase.com](https://supabase.com/) and create a new project.
+2. Choose a **database password** and wait for the project to be provisioned.
+
+## 2. Obtain API keys
+1. In your Supabase project navigate to **Settings → API**.
+2. Copy the **Project URL** – this becomes `SUPABASE_URL`.
+3. Copy the **anon public key** – this becomes `SUPABASE_ANON_KEY`.
+4. Copy the **service role key** – this becomes `SUPABASE_SERVICE_ROLE_KEY`.
+5. Under **Database → Connection string** copy the **URI** for the PostgreSQL connection. This value will be used for `DATABASE_URL`.
+
+## 3. Configure environment variables
+Update `.env.local` (or `.env.example` when sharing) with the values you copied:
+
+```bash
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+DATABASE_URL=postgresql://username:password@db.your-project.supabase.co:5432/postgres
+```
+
+## 4. Run Prisma migrations
+After configuring the variables, install dependencies and run the migrations:
+
+```bash
+npx prisma migrate dev
+```
+
+This command creates the database schema in your Supabase PostgreSQL instance.


### PR DESCRIPTION
## Summary
- add `SUPABASE_SETUP.md` with steps to create a project and run Prisma migrations
- extend `.env.example` with Supabase variables
- link new guide from README

## Testing
- `npm run lint` *(fails: no-img-element and restricted-syntax errors)*
- `npm test` *(fails: type errors in AuthGuard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68628c219bb083209e23619b0b95cf85